### PR TITLE
Fix error when processing events from and account not in the 'account map'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,6 @@ test-codepipeline:
 .PHONY: test-all
 test-all: test test-codepipeline
 	AWS_REGION=$(AWS_REGION) $(LAMBDA_TEST) --configFile=$(CONFIG_FILE) run -x test/context.json -j test/sns-cloudwatch-event.json
-	AWS_REGION=$(AWS_REGION) $(LAMBDA_TEST) --configFile=$(CONFIG_FILE) run -x test/context.json -j test/sns-codepipeline-event.json
 	AWS_REGION=$(AWS_REGION) $(LAMBDA_TEST) --configFile=$(CONFIG_FILE) run -x test/context.json -j test/sns-event.json
 	AWS_REGION=$(AWS_REGION) $(LAMBDA_TEST) --configFile=$(CONFIG_FILE) run -x test/context.json -j test/sns-elastic-beanstalk-event.json
 	AWS_REGION=$(AWS_REGION) $(LAMBDA_TEST) --configFile=$(CONFIG_FILE) run -x test/context.json -j test/sns-codedeploy-event.json

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,7 @@ test-all: test test-codepipeline
 	AWS_REGION=$(AWS_REGION) $(LAMBDA_TEST) --configFile=$(CONFIG_FILE) run -x test/context.json -j test/sns-codedeploy-configuration.json
 	AWS_REGION=$(AWS_REGION) $(LAMBDA_TEST) --configFile=$(CONFIG_FILE) run -x test/context.json -j test/sns-elasticache-event.json
 	AWS_REGION=$(AWS_REGION) $(LAMBDA_TEST) --configFile=$(CONFIG_FILE) run -x test/context.json -j test/sns-autoscaling-event.json
+	AWS_REGION=$(AWS_REGION) $(LAMBDA_TEST) --configFile=$(CONFIG_FILE) run -x test/context.json -j test/sns-config-event.json
 
 .PHONY: package
 package:

--- a/index.js
+++ b/index.js
@@ -62,7 +62,7 @@ var postMessage = function(message, callback) {
   postReq.end();
 };
 
-var handleElasticBeanstalk = function(event, context) {
+var handleElasticBeanstalk = function(event) {
   var timestamp = (new Date(event.Records[0].Sns.Timestamp)).getTime()/1000;
   var subject = event.Records[0].Sns.Subject || "AWS Elastic Beanstalk Notification";
   var message = event.Records[0].Sns.Message;
@@ -110,7 +110,7 @@ var handleElasticBeanstalk = function(event, context) {
   return _.merge(slackMessage, baseSlackMessage);
 };
 
-var handleCodeDeploy = function(event, context) {
+var handleCodeDeploy = function(event) {
   var subject = "AWS CodeDeploy Notification";
   var timestamp = (new Date(event.Records[0].Sns.Timestamp)).getTime()/1000;
   var snsSubject = event.Records[0].Sns.Subject;
@@ -157,10 +157,9 @@ var handleCodeDeploy = function(event, context) {
   return _.merge(slackMessage, baseSlackMessage);
 };
 
-var handleCodePipeline = function(event, context) {
+var handleCodePipeline = function(event) {
   var subject = "AWS CodePipeline Notification";
   var timestamp = (new Date(event.Records[0].Sns.Timestamp)).getTime()/1000;
-  var snsSubject = event.Records[0].Sns.Subject;
   var message;
   var fields = [];
   var color = "warning";
@@ -216,7 +215,7 @@ var handleCodePipeline = function(event, context) {
   return _.merge(slackMessage, baseSlackMessage);
 };
 
-var handleElasticache = function(event, context) {
+var handleElasticache = function(event) {
   var subject = "AWS ElastiCache Notification"
   var message = JSON.parse(event.Records[0].Sns.Message);
   var timestamp = (new Date(event.Records[0].Sns.Timestamp)).getTime()/1000;
@@ -250,7 +249,7 @@ var handleElasticache = function(event, context) {
   return _.merge(slackMessage, baseSlackMessage);
 };
 
-var handleCloudWatch = function(event, context) {
+var handleCloudWatch = function(event) {
   var timestamp = (new Date(event.Records[0].Sns.Timestamp)).getTime()/1000;
   var message = JSON.parse(event.Records[0].Sns.Message);
   var region = event.Records[0].EventSubscriptionArn.split(":")[3];
@@ -263,9 +262,7 @@ var handleCloudWatch = function(event, context) {
   var namespace = message.Trigger.Namespace;
   var dimensions = message.Trigger.Dimensions || [];
   var dimensionsText = "";
-  var oldState = message.OldStateValue;
   var newState = message.NewStateValue;
-  var alarmDescription = message.AlarmDescription;
   var alarmReason = message.NewStateReason;
   var trigger = message.Trigger;
   var color = "warning";
@@ -319,10 +316,9 @@ var handleCloudWatch = function(event, context) {
   return _.merge(slackMessage, baseSlackMessage);
 };
 
-var handleConfigCompliance = function(event, context) {
+var handleConfigCompliance = function(event) {
   var timestamp = (new Date(event.Records[0].Sns.Timestamp)).getTime()/1000;
   var message = JSON.parse(event.Records[0].Sns.Message);
-  var region = event.Records[0].EventSubscriptionArn.split(":")[3];
   var ruleRegion = message.region;
   var accountId = message.account;
   var accountName = deriveAccountName(accountId);
@@ -364,10 +360,9 @@ var handleConfigCompliance = function(event, context) {
   return _.merge(slackMessage, baseSlackMessage);
 };
 
-var handleGuardDutyFinding = function(event, context) {
+var handleGuardDutyFinding = function(event) {
   var timestamp = (new Date(event.Records[0].Sns.Timestamp)).getTime()/1000;
   var message = JSON.parse(event.Records[0].Sns.Message);
-  var region = event.Records[0].EventSubscriptionArn.split(":")[3];
   var ruleRegion = message.detail.region;
   var accountId = message.detail.accountId;
   var accountName = deriveAccountName(accountId);
@@ -417,11 +412,10 @@ var handleGuardDutyFinding = function(event, context) {
   return _.merge(slackMessage, baseSlackMessage);
 };
 
-var handleAutoScaling = function(event, context) {
+var handleAutoScaling = function(event) {
   var subject = "AWS AutoScaling Notification"
   var message = JSON.parse(event.Records[0].Sns.Message);
   var timestamp = (new Date(event.Records[0].Sns.Timestamp)).getTime()/1000;
-  var eventname, nodename;
   var color = "good";
 
   for(key in message){
@@ -448,7 +442,7 @@ var handleAutoScaling = function(event, context) {
   return _.merge(slackMessage, baseSlackMessage);
 };
 
-var handleCatchAll = function(event, context) {
+var handleCatchAll = function(event) {
 
     var record = event.Records[0]
     var subject = record.Sns.Subject
@@ -499,35 +493,35 @@ var processEvent = function(event, context) {
 
   if(eventSubscriptionArn.indexOf(config.services.codepipeline.match_text) > -1 || eventSnsSubject.indexOf(config.services.codepipeline.match_text) > -1 || eventSnsMessage.indexOf(config.services.codepipeline.match_text) > -1){
     console.log("processing codepipeline notification");
-    slackMessage = handleCodePipeline(event,context)
+    slackMessage = handleCodePipeline(event)
   }
   else if(eventSubscriptionArn.indexOf(config.services.elasticbeanstalk.match_text) > -1 || eventSnsSubject.indexOf(config.services.elasticbeanstalk.match_text) > -1 || eventSnsMessage.indexOf(config.services.elasticbeanstalk.match_text) > -1){
     console.log("processing elasticbeanstalk notification");
-    slackMessage = handleElasticBeanstalk(event,context)
+    slackMessage = handleElasticBeanstalk(event)
   }
   else if(eventSubscriptionArn.indexOf(config.services.cloudwatch.match_text) > -1 || eventSnsSubject.indexOf(config.services.cloudwatch.match_text) > -1 || eventSnsMessage.indexOf(config.services.cloudwatch.match_text) > -1){
     console.log("processing cloudwatch notification");
-    slackMessage = handleCloudWatch(event,context);
+    slackMessage = handleCloudWatch(event);
   }
   else if(eventSubscriptionArn.indexOf(config.services.codedeploy.match_text) > -1 || eventSnsSubject.indexOf(config.services.codedeploy.match_text) > -1 || eventSnsMessage.indexOf(config.services.codedeploy.match_text) > -1){
     console.log("processing codedeploy notification");
-    slackMessage = handleCodeDeploy(event,context);
+    slackMessage = handleCodeDeploy(event);
   }
   else if(eventSubscriptionArn.indexOf(config.services.elasticache.match_text) > -1 || eventSnsSubject.indexOf(config.services.elasticache.match_text) > -1 || eventSnsMessage.indexOf(config.services.elasticache.match_text) > -1){
     console.log("processing elasticache notification");
-    slackMessage = handleElasticache(event,context);
+    slackMessage = handleElasticache(event);
   }
   else if(eventSubscriptionArn.indexOf(config.services.autoscaling.match_text) > -1 || eventSnsSubject.indexOf(config.services.autoscaling.match_text) > -1 || eventSnsMessage.indexOf(config.services.autoscaling.match_text) > -1){
     console.log("processing autoscaling notification");
-    slackMessage = handleAutoScaling(event, context);
+    slackMessage = handleAutoScaling(event);
   }
   else if(eventSubscriptionArn.indexOf(config.services.configcompliance.match_text) > -1 || eventSnsSubject.indexOf(config.services.configcompliance.match_text) > -1 || eventSnsMessage.indexOf(config.services.configcompliance.match_text) > -1){
     console.log("processing config compliance notification");
-    slackMessage = handleConfigCompliance(event, context);
+    slackMessage = handleConfigCompliance(event);
   }
   else if(eventSubscriptionArn.indexOf(config.services.guarddutyfinding.match_text) > -1 || eventSnsSubject.indexOf(config.services.guarddutyfinding.match_text) > -1 || eventSnsMessage.indexOf(config.services.guarddutyfinding.match_text) > -1){
     console.log("processing guard duty finding");
-    slackMessage = handleGuardDutyFinding(event, context);
+    slackMessage = handleGuardDutyFinding(event);
   }
   else{
     slackMessage = handleCatchAll(event, context);

--- a/index.js
+++ b/index.js
@@ -549,7 +549,7 @@ exports.handler = function(event, context) {
     hookUrl = config.unencryptedHookUrl;
     processEvent(event, context);
   } else if (config.kmsEncryptedHookUrl && config.kmsEncryptedHookUrl !== '<kmsEncryptedHookUrl>') {
-    var encryptedBuf = new Buffer(config.kmsEncryptedHookUrl, 'base64');
+    var encryptedBuf = Buffer.from(config.kmsEncryptedHookUrl, 'base64');
     var cipherText = { CiphertextBlob: encryptedBuf };
     var kms = new AWS.KMS();
 

--- a/index.js
+++ b/index.js
@@ -17,8 +17,8 @@ var baseSlackMessage = {
   ]
 }
 
-var deriveAccountName = function(accountId) {
-  var accountIdMap = JSON.parse(config.awsAccountMap).accounts;
+const deriveAccountName = function(accountId) {
+  const accountIdMap = JSON.parse(config.awsAccountMap).accounts;
 
   if (accountIdMap) {
     const account = _.find(accountIdMap, { accountId: accountId });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,323 @@
+{
+  "name": "lambda-cloudwatch-slack",
+  "version": "0.2.1",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "async": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+      "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=",
+      "dev": true
+    },
+    "aws-sdk": {
+      "version": "2.600.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.600.0.tgz",
+      "integrity": "sha512-ySgOVN7plt4g3SmbvAz6fD8aefcmU/IjgogiEgal5BZB5ad5o99MOFwcTILRSLF9rDyoKAHNE3hx0Jcie6XsBQ==",
+      "requires": {
+        "buffer": "4.9.1",
+        "events": "1.1.1",
+        "ieee754": "1.1.13",
+        "jmespath": "0.15.0",
+        "querystring": "0.2.0",
+        "sax": "1.2.1",
+        "url": "0.10.3",
+        "uuid": "3.3.2",
+        "xml2js": "0.4.19"
+      },
+      "dependencies": {
+        "url": {
+          "version": "0.10.3",
+          "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+          "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
+          "requires": {
+            "punycode": "1.3.2",
+            "querystring": "0.2.0"
+          }
+        }
+      }
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "base64-js": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
+      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "buffer": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+      "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
+      "requires": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
+      }
+    },
+    "commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "dotenv": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-0.4.0.tgz",
+      "integrity": "sha1-9vs1E2PC2SIHJFxzeALJq1rhSVo=",
+      "dev": true
+    },
+    "events": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
+    },
+    "fs-extra": {
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
+      "integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^2.1.0",
+        "klaw": "^1.0.0",
+        "path-is-absolute": "^1.0.0",
+        "rimraf": "^2.2.8"
+      }
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "glob": {
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "graceful-fs": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
+      "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
+      "dev": true
+    },
+    "https": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/https/-/https-1.0.0.tgz",
+      "integrity": "sha1-PDfHrhqO65ZpBKKtHpdaGUt+06Q="
+    },
+    "ieee754": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+    },
+    "jmespath": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
+      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
+    },
+    "jsonfile": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+      "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "jszip": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-2.5.0.tgz",
+      "integrity": "sha1-dET9hVHd8+XacZj+oMkbyDCMwnQ=",
+      "dev": true,
+      "requires": {
+        "pako": "~0.2.5"
+      }
+    },
+    "klaw": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
+      "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.9"
+      }
+    },
+    "lodash": {
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "node-lambda": {
+      "version": "0.8.11",
+      "resolved": "https://registry.npmjs.org/node-lambda/-/node-lambda-0.8.11.tgz",
+      "integrity": "sha1-sMYCZhpuzA5QczHa47ny+Rbxe+I=",
+      "dev": true,
+      "requires": {
+        "async": "^0.9.0",
+        "aws-sdk": "^2.1.24",
+        "commander": "^2.5.0",
+        "dotenv": "^0.4.0",
+        "fs-extra": "^0.30.0",
+        "node-uuid": "^1.4.2",
+        "node-zip": "^1.1.0",
+        "rimraf": "^2.2.8"
+      },
+      "dependencies": {
+        "node-uuid": {
+          "version": "1.4.8",
+          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
+          "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc=",
+          "dev": true
+        }
+      }
+    },
+    "node-zip": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/node-zip/-/node-zip-1.1.1.tgz",
+      "integrity": "sha1-lNGtZ0o81GoViN1zb0qaeMdX62I=",
+      "dev": true,
+      "requires": {
+        "jszip": "2.5.0"
+      }
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "pako": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+      "integrity": "sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU=",
+      "dev": true
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "punycode": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+      "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+    },
+    "querystring": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
+    },
+    "rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.1.3"
+      }
+    },
+    "sax": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+      "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
+    },
+    "url": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
+      "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
+      "requires": {
+        "punycode": "1.3.2",
+        "querystring": "0.2.0"
+      }
+    },
+    "uuid": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "xml2js": {
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+      "requires": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~9.0.1"
+      }
+    },
+    "xmlbuilder": {
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
+    }
+  }
+}

--- a/test/sns-config-event.json
+++ b/test/sns-config-event.json
@@ -1,0 +1,22 @@
+{
+  "Records": [
+      {
+          "EventSource": "aws:sns",
+          "EventVersion": "1.0",
+          "EventSubscriptionArn": "arn:aws:sns:ap-southeast-2:390556333961:notify-warning:427bab3c-6e54-43af-9fa5-1f8f8e083c7b",
+          "Sns": {
+              "Type": "Notification",
+              "MessageId": "dffaaa50-ef10-5d73-96f4-fcded9a967d7",
+              "TopicArn": "arn:aws:sns:ap-southeast-2:390556333961:notify-warning",
+              "Subject": "Config Rules Compliance Change",
+              "Message": "{\n    \"version\": \"0\",\n    \"id\": \"86d73788-6877-ce78-fe1f-73ffd02b6b6c\",\n    \"detail-type\": \"Config Rules Compliance Change\",\n    \"source\": \"aws.config\",\n    \"account\": \"111111111111111\",\n    \"time\": \"2020-01-07T07:34:08Z\",\n    \"region\": \"ap-southeast-2\",\n    \"resources\": [],\n    \"detail\": {\n        \"resourceId\": \"ANPA56J6477MY7DTJMNIM\",\n        \"awsRegion\": \"ap-southeast-2\",\n        \"awsAccountId\": \"111111111111111\",\n        \"configRuleName\": \"IAM_POLICY_NO_STATEMENTS_WITH_ADMIN_ACCESS\",\n        \"recordVersion\": \"1.0\",\n        \"configRuleARN\": \"arn:aws:config:ap-southeast-2:958446501849:config-rule/config-rule-xququw\",\n        \"messageType\": \"ComplianceChangeNotification\",\n        \"newEvaluationResult\": {\n            \"evaluationResultIdentifier\": {\n                \"evaluationResultQualifier\": {\n                    \"configRuleName\": \"IAM_POLICY_NO_STATEMENTS_WITH_ADMIN_ACCESS\",\n                    \"resourceType\": \"AWS::IAM::Policy\",\n                    \"resourceId\": \"ANPA56J6477MY7DTJMNIM\"\n                },\n                \"orderingTimestamp\": \"2020-01-07T07:33:42.535Z\"\n            },\n            \"complianceType\": \"COMPLIANT\",\n            \"resultRecordedTime\": \"2020-01-07T07:34:07.861Z\",\n            \"configRuleInvokedTime\": \"2020-01-07T07:34:07.695Z\"\n        },\n        \"notificationCreationTime\": \"2020-01-07T07:34:08.932Z\",\n        \"resourceType\": \"AWS::IAM::Policy\"\n    }\n}",
+              "Timestamp": "2020-01-07T07:34:17.382Z",
+              "SignatureVersion": "1",
+              "Signature": "jQER/N+z4ho2/1XRRMVESlaU2Qn+YJNMjUrQ45Cn0VIej4XTJ4flbjMQ+NszwPXyLB17Vfkw4JAlD4nGF8gWJqd+m050oZLAhRL1NybVDZnqJYmoMhucEctEsSsnZ5I8Nw5B2N1MGQc6C1hJ4GK0kqtErRQQmRn6t0bJA9puwzOU8bt3ZkuebZf1ScdYQAy6tOqqDdWKPHF+iZJI0SowZCuh7DaIxIxnDFI+uKZvCo57OTpzm1QkQDZtd1OYbqqNj1bDHseQRWRGZFFuXHKh87O0Cwld2M7q0vK7UpjPZO6o/c77cvlyj9ZZApkRP0HJavM0SFd06yD9A4417Up5+g==",
+              "SigningCertUrl": "https://sns.ap-southeast-2.amazonaws.com/SimpleNotificationService-6aad65c2f9911b05cd53efda11f913f9.pem",
+              "UnsubscribeUrl": "https://sns.ap-southeast-2.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:ap-southeast-2:390556333961:notify-warning:427bab3c-6e54-43af-9fa5-1f8f8e083c7b",
+              "MessageAttributes": {}
+          }
+      }
+  ]
+}


### PR DESCRIPTION
This code used a map supplied as an ENV at runtime to convert from account IDs to friendly names, however it assumed that all possible accounts were specified. If a new account is set up, or an account is missed in the map, this code would explode and fail to deliver the notification.

This change makes the look up resilient, defaulting to just using the account ID if it's not in the map.

It also fixes:
- A deprecation warning on `new Buffer(foo)`
- Removes a test case that didn't exist, causing the tests to fail
- Adds a test for config rule notifications
- Removes a bunch of dead code
- Commits the `package-lock.json`