### PR TITLE
KZNSYSADMIN-304 health notifications

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,7 @@ test-all: test test-codepipeline
 	AWS_REGION=$(AWS_REGION) $(LAMBDA_TEST) --configFile=$(CONFIG_FILE) run -x test/context.json -j test/sns-config-event.json
 	AWS_REGION=$(AWS_REGION) $(LAMBDA_TEST) --configFile=$(CONFIG_FILE) run -x test/context.json -j test/sns-codebuild-state-failed-event.json
 	AWS_REGION=$(AWS_REGION) $(LAMBDA_TEST) --configFile=$(CONFIG_FILE) run -x test/context.json -j test/sns-codepipeline-deploy-failed.json
+	AWS_REGION=$(AWS_REGION) $(LAMBDA_TEST) --configFile=$(CONFIG_FILE) run -x test/context.json -j test/sns-health-issue.json
 
 .PHONY: package
 package:

--- a/config.js
+++ b/config.js
@@ -45,7 +45,7 @@ module.exports = {
     guarddutyfinding: {
       match_text: "GuardDuty Finding"
     },
-    ec2retirementscheduled: {
+    health: {
       match_text: "aws.health"
     }
   }

--- a/index.js
+++ b/index.js
@@ -454,14 +454,18 @@ var handleGuardDutyFinding = function(event) {
   return _.merge(slackMessage, baseSlackMessage);
 };
 
-var handleEC2RetirementScheduled = function(event) {
+const handleHealth = function(event) {
 
-  var subject = event.Records[0].Sns.Subject;
-  var timestamp = new Date(event.Records[0].Sns.Timestamp).getTime() / 1000;
-  var message = JSON.parse(event.Records[0].Sns.Message);
-  var color = "warning";
+  const subject = event.Records[0].Sns.Subject;
+  const timestamp = new Date(event.Records[0].Sns.Timestamp).getTime() / 1000;
+  const message = JSON.parse(event.Records[0].Sns.Message);
+  const color = "warning";
+  const resources = Array.isArray(message.resources) ? message.resources.join(', ') : '';
+  const description = Array.isArray(message.detail.eventDescription)
+    ? message.detail.eventDescription.map(d => d.latestDescription).join(', ')
+    : '';
 
-  var slackMessage = {
+  const slackMessage = {
     text: "*" + subject + "*",
     attachments: [
       {
@@ -470,13 +474,13 @@ var handleEC2RetirementScheduled = function(event) {
           { "title": "Account", "value": deriveAccountName(message.account), "short": true },
           { "title": "Region", "value": message.region, "short": true },
           { "title": "Event", "value": message.detail['eventTypeCode'], "short": true },
-          { "title": "Resource", "value": message.resources[0], "short": true },
-          { "title": "EventArn", "value": message.detail['eventArn'], "short": true },
+          { "title": "Resource", "value": resources, "short": true },
           {
-            "title": "Link to Event",
-            "value": " https://" + message.region + ".console.aws.amazon.com/ec2/v2/home?region=" + message.region + "#Events:",
+            "title": "Health Dashboard",
+            "value": "https://phd.aws.amazon.com/phd/home#/dashboard/open-issues",
             "short": false
-          }
+          },
+          { "title": "Description", "value": description, "short": false }
         ],
         "ts":  timestamp
       }
@@ -609,9 +613,9 @@ var processEvent = function(event, context) {
   } else if(eventMatches(event, config.services.guarddutyfinding.match_text)) {
     console.log("processing guard duty finding");
     slackMessage = handleGuardDutyFinding(event);
-  } else if(eventMatchesSource(event, config.services.ec2retirementscheduled.match_text)) {
+  } else if(eventMatchesSource(event, config.services.health.match_text)) {
     console.log("processing EC2 Retirement Scheduled");
-    slackMessage = handleEC2RetirementScheduled(event);
+    slackMessage = handleHealth(event);
   } else {
     slackMessage = handleCatchAll(event);
   }

--- a/index.js
+++ b/index.js
@@ -222,9 +222,9 @@ const handleCodeBuild = function(event) {
   if (message.detail['build-status'] === "SUCCEEDED"){
     color = "good";
   } else if(message.detail['build-status'] === "IN_PROGRESS"){
-    color = "warning";
+    color = "good";
   } else if(['FAILED', 'STOPPED'].includes(message.detail['build-status'])){
-    color = "danger";
+    color = "warning";
   }
 
   const failedPhase = message.detail['additional-information'].phases.find(p => p['phase-status'] === 'FAILED');

--- a/test/sns-health-issue.json
+++ b/test/sns-health-issue.json
@@ -1,0 +1,27 @@
+{
+    "Records": [
+        {
+            "EventSource": "aws:sns",
+            "EventVersion": "1.0",
+            "EventSubscriptionArn": "arn:aws:sns:ap-southeast-2:111111111111:notify-error:209a2910-ecfb-4439-9e40-134d9050418f",
+            "Sns": {
+                "Type": "Notification",
+                "MessageId": "82262b9b-3bf4-5e9f-a70d-7d36edbcaa40",
+                "TopicArn": "arn:aws:sns:ap-southeast-2:111111111111:notify-error",
+                "Subject": "AWS Health Event",
+                "Message": "{\"version\":\"0\",\"id\":\"7bf73129-1428-4cd3-a780-95db273d1602\",\"detail-type\":\"AWS Health Event\",\"source\":\"aws.health\",\"account\":\"123456789012\",\"time\":\"2016-06-05T06:27:57Z\",\"region\":\"us-west-2\",\"resources\":[\"i-abcd1111\"],\"detail\":{\"eventArn\":\"arn:aws:health:us-west-2::event/AWS_EC2_INSTANCE_STORE_DRIVE_PERFORMANCE_DEGRADED_90353408594353980\",\"service\":\"EC2\",\"eventTypeCode\":\"AWS_EC2_INSTANCE_STORE_DRIVE_PERFORMANCE_DEGRADED\",\"eventTypeCategory\":\"issue\",\"startTime\":\"Sat, 05 Jun 2016 15:10:09 GMT\",\"eventDescription\":[{\"language\":\"en_US\",\"latestDescription\":\"A description of the event will be provided here\"}],\"affectedEntities\":[{\"entityValue\":\"i-abcd1111\",\"tags\":{\"stage\":\"prod\",\"app\":\"my-app\"}}]}}",
+                "Timestamp": "2020-01-31T07:15:20.684Z",
+                "SignatureVersion": "1",
+                "Signature": "eGvU16abHP8PTmbCkmU/6kxvot+eKqhNOlKX6jttIINGM/mpMEwuNLxbkS7os2U3XnqR3Jbdeff/Hj4ucP6JH1x8SGRZrYKoQBiTzpZZYAvQOQj2TkwkTxkSNwk2uivvzhJmdfOUrTDXqEf6yO/fllJichjkRtA7sp5ZD3ogSjcFAAKb/nMtJfkni3NxVa5YYmJONxm8GBzt+wq/tbumgPiZF8mPq3j8/cwDl3qwN0GhfhbXkZTtibMoZZDyruxOCmYSofKlLWXNmq+JzUrX31R7nZL1noe5D4Rf2+1UckjrvSOCkA+QuCq4jUFnTW2xanqLvoFieVns3Zs6ok/Lgg==",
+                "SigningCertUrl": "https://sns.ap-southeast-2.amazonaws.com/SimpleNotificationService-a86cb10b4e1f29c941702d737128f7b6.pem",
+                "UnsubscribeUrl": "https://sns.ap-southeast-2.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:ap-southeast-2:111111111111:notify-error:209a2910-ecfb-4439-9e40-134d9050418f",
+                "MessageAttributes": {
+                    "Test": {
+                        "Type": "String",
+                        "Value": "TEST"
+                    }
+                }
+            }
+        }
+    ]
+}


### PR DESCRIPTION
Story: https://kzngroup.atlassian.net/browse/KZNSYSADM-304

Updates the `EC2 instance retirement` processor and turns it into a general purpose health notification.

Goes with: https://github.com/KZNGroup/aws-cloudformation/pull/346

I changed the URL to one that points at the "Personal Health Dashboard" that shows all current 'issues' (such as what's displayed on https://status.aws.amazon.com/) plus all 'notifications' (such as "python 2 is deprecated and your lambda xyz will stop working").

I also reduced the priority of my recent CodeBuild notifications.